### PR TITLE
Use `image/x-sld` for AutoCAD slides

### DIFF
--- a/src/megaext.c
+++ b/src/megaext.c
@@ -584,7 +584,7 @@ static const struct { const char* ext; const char* name; const char* mime; const
 	{"skb", "SketchUp Document", "application/octet-stream", "0"},
 	{"skp", "SSEYO Koan File", "application/vnd.koan", "0"},
 	{"sla", "Scribus", "application/vnd.scribus", "0"},
-	{"sld", "AutoCAD Slide", "application/sld", "0"},
+	{"sld", "AutoCAD Slide", "image/x-sld", "0"},
 	{"sldm", "Microsoft PowerPoint Macro-Enabled Slide 2007", "application/vnd.ms-powerpoint.slide.macroenabled.12;version=\"2007\"", "0"},
 	{"sldprt", "SolidWorks CAD program", "application/sldworks", "0"},
 	{"slim", "Slim", "text/x-slim", "0"},


### PR DESCRIPTION
[PRONOM](https://www.nationalarchives.gov.uk/PRONOM/x-fmt/105) lists AutoCAD slides with 3 confusing MIME types that aren't actually registered with IANA. Since it's not a standard, `application/sld` is incorrect, and it has a conflict risk with `application/vnd.ogc.sld+xml` anyway due to the file extension.

I'm importing these bitmaps into `pillow` using `netpbm`, and going around the internet and trying to fix this as a side quest. PRONOM will likely take a long time and depends on IANA registration of `image/vnd.autodesk.slide` which will take even longer, so for the moment I think `image/x-sld` is the correct type to use - the more alignment we have on this, the better a time archivists will have in future.

Thanks!

Gareth